### PR TITLE
Pass movesubpages to API in move()

### DIFF
--- a/lib/MediaWiki/Bot.pm
+++ b/lib/MediaWiki/Bot.pm
@@ -755,8 +755,9 @@ sub move {
         to     => $to,
         reason => $reason,
     };
-    $hash->{movetalk}   = $opts->{movetalk}   if defined($opts->{movetalk});
-    $hash->{noredirect} = $opts->{noredirect} if defined($opts->{noredirect});
+    $hash->{movetalk}     = $opts->{movetalk}     if defined($opts->{movetalk});
+    $hash->{noredirect}   = $opts->{noredirect}   if defined($opts->{noredirect});
+    $hash->{movesubpages} = $opts->{movesubpages} if defined($opts->{movesubpages});
 
     my $res = $self->{api}->edit($hash);
     return $self->_handle_api_error() unless $res;


### PR DESCRIPTION
I kept on wondering, why does only one page get moved with `{ movesubpages => 1 }`?  Looks like the option never gets passed to the API, so it was a nice one-line fix that works for me.  You have `watch`, `unwatch`, and `ignorewarnings` in the documentation, but they also don't get added to the API call -- those might need to be added too.
