### PR TITLE
fix test t/25-sitematrix.t

### DIFF
--- a/lib/MediaWiki/Bot.pm
+++ b/lib/MediaWiki/Bot.pm
@@ -2588,15 +2588,17 @@ sub db_to_domain {
     if (ref $wiki eq 'ARRAY') {
         my @return;
         foreach my $w (@$wiki) {
-            $wiki =~ s/_p$//;    # Strip off a _p suffix, if present
+            $wiki =~ s/_p$//;                               # Strip off a _p suffix, if present
             my $domain = $self->{sitematrix}->{$w} || undef;
+            $domain =~ s/^https\:\/\/// if (defined $domain); # Strip off a https:// prefix, if present
             push(@return, $domain);
         }
         return \@return;
     }
     else {
-        $wiki =~ s/_p$//;        # Strip off a _p suffix, if present
+        $wiki =~ s/_p$//;                                   # Strip off a _p suffix, if present
         my $domain = $self->{sitematrix}->{$wiki} || undef;
+        $domain =~ s/^https\:\/\/// if (defined $domain);   # Strip off a https:// prefix, if present
         return $domain;
     }
 }
@@ -2623,12 +2625,14 @@ sub domain_to_db {
     if (ref $wiki eq 'ARRAY') {
         my @return;
         foreach my $w (@$wiki) {
+            $w = "https://".$w if ($w !~ /^https\:\//); # Prepend a https:// prefix, if not present
             my $db = $self->{sitematrix}->{$w} || undef;
             push(@return, $db);
         }
         return \@return;
     }
     else {
+        $wiki = "https://".$wiki if ($wiki !~ /^https\:\//); # Prepend a https:// prefix, if not present
         my $db = $self->{sitematrix}->{$wiki} || undef;
         return $db;
     }


### PR DESCRIPTION
Simple stripping & prepending of URI prefix where needed for test to
pass, 2nd possibility was to change test itself, but I like to keep
backwards compatibility as much as possible. :)

I used both PHP & Perl MediaWiki bots, I recently made needed corrections to my PHP bot to be functional because of upstream API.php changes, I intend to do the same for Perl MediaWiki-Bot.
First, I'm fixing things that are making tests FAIL on my dev machine, creating one pull request for one test fixed (easier to troubleshoot if needed).