### PR TITLE
fix(history): api param 'direction' -> 'rvdir'

### DIFF
--- a/lib/MediaWiki/Bot.pm
+++ b/lib/MediaWiki/Bot.pm
@@ -2853,6 +2853,7 @@ sub search {
     my $hash = {
         action   => 'query',
         list     => 'search',
+        srnamespace => $ns,
         srsearch => $term,
         srwhat   => 'text',
         srlimit  => 'max',

--- a/lib/MediaWiki/Bot.pm
+++ b/lib/MediaWiki/Bot.pm
@@ -897,7 +897,7 @@ sub get_history {
     };
 
     $hash->{rvstartid} = $rvstartid if ($rvstartid);
-    $hash->{direction} = $direction if ($direction);
+    $hash->{rvdir}     = $direction if ($direction);
 
     my $res = $self->{api}->api($hash);
     return $self->_handle_api_error() unless $res;


### PR DESCRIPTION
1. the name of the direction parameter is 'rvdir' and not 'direction'
2. the search ignored the namespace param