### PR TITLE
fix(history): api param 'direction' -> 'rvdir'

### DIFF
--- a/lib/MediaWiki/Bot.pm
+++ b/lib/MediaWiki/Bot.pm
@@ -897,7 +897,7 @@ sub get_history {
     };
 
     $hash->{rvstartid} = $rvstartid if ($rvstartid);
-    $hash->{direction} = $direction if ($direction);
+    $hash->{rvdir}     = $direction if ($direction);
 
     my $res = $self->{api}->api($hash);
     return $self->_handle_api_error() unless $res;


### PR DESCRIPTION
the name of the direction parameter is 'rvdir' and not 'direction', see https://www.mediawiki.org/w/api.php?action=help&modules=query%2Brevisions

fixes #88 