### PR TITLE
fix(search): make use of namespace param

### DIFF
--- a/lib/MediaWiki/Bot.pm
+++ b/lib/MediaWiki/Bot.pm
@@ -2853,6 +2853,7 @@ sub search {
     my $hash = {
         action   => 'query',
         list     => 'search',
+        srnamespace => $ns,
         srsearch => $term,
         srwhat   => 'text',
         srlimit  => 'max',


### PR DESCRIPTION
namespace param was unused in search. now it is used.

fixes #87