### PR TITLE
feat(is_blocked): return more information

### DIFF
--- a/lib/MediaWiki/Bot.pm
+++ b/lib/MediaWiki/Bot.pm
@@ -2087,6 +2087,9 @@ sub links_to_image {
     my $blocked = $bot->is_blocked('User:Mike.lifeguard');
 
 Checks if a user is currently blocked.
+Returns false (!!0), if a user is not blocked.
+Returns a hash ref with the information about the block, see API
+reference for details.
 
 B<References:> L<API:Blocks|https://www.mediawiki.org/wiki/API:Blocks>
 
@@ -2096,20 +2099,19 @@ sub is_blocked {
     my $self = shift;
     my $user = shift;
 
-    # http://en.wikipedia.org/w/api.php?action=query&meta=blocks&bkusers=$user&bklimit=1&bkprop=id
+    # http://en.wikipedia.org/w/api.php?action=query&meta=blocks&bkusers=$user&bklimit=1
     my $hash = {
         action  => 'query',
         list    => 'blocks',
         bkusers => $user,
         bklimit => 1,
-        bkprop  => 'id',
     };
     my $res = $self->{api}->api($hash);
     return $self->_handle_api_error() unless $res;
 
     my $number = scalar @{ $res->{query}->{blocks} }; # The number of blocks returned
     if ($number == 1) {
-        return RET_TRUE;
+        return $res->{query}{blocks}[0];
     }
     elsif ($number == 0) {
         return RET_FALSE;


### PR DESCRIPTION
fixes #6
BREAKING CHANGE: the returned positive value is not 1 any longer, but a hash ref (which evaluates to true in a simple if condition).

i'm not 100% sure, whether this is a good idea or whether a separate function would be better to be downward-compatible and consistent with other similar functions. however, i feel more comfortable as a user, if a function gives me more information on top.