### PR TITLE
Feat/93 revised get text and get

### DIFF
--- a/lib/MediaWiki/Bot.pm
+++ b/lib/MediaWiki/Bot.pm
@@ -895,16 +895,16 @@ sub get_history {
     my $self      = shift;
     my $pagename  = shift;
     my $additional_params = shift // {};
-		# for backward-compatibility check for textual params
-		if(ref $additional_params eq ''){
-			my $rvlimit = $additional_params;
-			my $rvstartid = shift;
-			my $rvdir = shift;
-			$additional_params = {};
-			$additional_params->{'rvlimit'} = $rvlimit if $rvlimit;
-			$additional_params->{'rvstartid'} = $rvstartid if $rvstartid;
-			$additional_params->{'rvdir'} = $rvdir if $rvdir;
-		}
+    # for backward-compatibility check for textual params
+    if(ref $additional_params eq ''){
+        my $rvlimit = $additional_params;
+        my $rvstartid = shift;
+        my $rvdir = shift;
+        $additional_params = {};
+        $additional_params->{'rvlimit'} = $rvlimit if $rvlimit;
+        $additional_params->{'rvstartid'} = $rvstartid if $rvstartid;
+        $additional_params->{'rvdir'} = $rvdir if $rvdir;
+    }
     my $ready;
     my $filter_params = {%$additional_params};
     my @full_hist;

--- a/lib/MediaWiki/Bot.pm
+++ b/lib/MediaWiki/Bot.pm
@@ -1086,10 +1086,15 @@ sub get_text {
 
 =head2 get_id
 
-Returns the id of the specified $page_title. Returns undef if page does not exist.
+Returns the id of the specified $page_title. Returns PAGE_NONEXISTENT (i.e. -1) if 
+page does not exist. Returns undef on error.
 
-    my $pageid = $bot->get_id("Main Page");
-    die "Page doesn't exist\n" if !defined($pageid);
+    my $page_id = $bot->get_id("Main Page");
+    die "could not get id of page.\n" unless defined $pageid;
+    warn "page doesn't exist\n" if $page_id == MediaWiki::Bot::PAGE_NONEXISTENT;
+
+    // or
+    die "could not get id of page.\n" unless ($page_id // -1) < 0;
 
 B<Revisions:> L<API:Properties#info|https://www.mediawiki.org/wiki/API:Properties#info_.2F_in>
 
@@ -1098,6 +1103,10 @@ B<Revisions:> L<API:Properties#info|https://www.mediawiki.org/wiki/API:Propertie
 sub get_id {
     my $self     = shift;
     my $pagename = shift;
+    unless(defined $pagename){
+        warn "get_id(): param \$pagename is not defined.\n" if $self->{'debug'} > 1;
+        return;
+    }
 
     my $hash = {
         action => 'query',
@@ -1107,8 +1116,7 @@ sub get_id {
     my $res = $self->{api}->api($hash);
     return $self->_handle_api_error() unless $res;
     my ($id) = %{ $res->{query}->{pages} };
-    return if $id == PAGE_NONEXISTENT;
-    return $id;
+    return $id; # $id might be PAGE_NONEXISTENT
 }
 
 =head2 get_pages

--- a/t/03-get_text.t
+++ b/t/03-get_text.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Test::RequiresInternet 'test.wikipedia.org' => 80;
-use Test::More tests => 6;
+use Test::More tests => 11;
 
 use MediaWiki::Bot;
 my $t = __FILE__;
@@ -19,9 +19,22 @@ is($wikitext, q{I know for a ''fact'' that this page contains 60 characters.}, '
 
 my $page = 'User:Mike.lifeguard/index';
 $wikitext = $bot->get_text($page);
-my $section_wikitext = $bot->get_text($page, undef, 2);
+my $section_wikitext = $bot->get_text($page, {'rvsection' => 2});
 isnt $section_wikitext => undef,             'Section load pass/fail';
 isnt $wikitext => $section_wikitext,         'Section loaded content correctly';
 like $wikitext => qr/\Q$section_wikitext\E/, 'Section loaded content correctly';
 
-is $bot->get_text('egaP niaM') => undef, 'No page found';
+# test backward-compatibility
+$section_wikitext = $bot->get_text($page, undef, 2);
+isnt $section_wikitext => undef,             'Section load pass/fail';
+isnt $wikitext => $section_wikitext,         'Section loaded content correctly';
+like $wikitext => qr/\Q$section_wikitext\E/, 'Section loaded content correctly';
+
+# page does not exist
+my $options = {};
+is $bot->get_text('egaP niaM', $options) => undef, 'No page found';
+is($options->{'pageid'}, MediaWiki::Bot::PAGE_NONEXISTENT, 'Check pageid, if no page found');
+
+# required param is missing
+my $result = $bot->get_text();
+is($result, undef, 'required param missing');

--- a/t/22-get_id.t
+++ b/t/22-get_id.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Test::RequiresInternet 'test.wikipedia.org' => 80;
-use Test::More tests => 2;
+use Test::More tests => 3;
 
 use MediaWiki::Bot;
 my $t = __FILE__;
@@ -14,5 +14,8 @@ my $bot = MediaWiki::Bot->new({
 my $result = $bot->get_id('Main Page');
 is($result, 11791, 'Main Page found');
 
-$result = $bot->get_text('egaP niaM');
-is($result, undef, 'No page found');
+$result = $bot->get_id('egaP niaM');
+is($result, MediaWiki::Bot::PAGE_NONEXISTENT, 'No page found');
+
+$result = $bot->get_id();
+is($result, undef, 'param missing');


### PR DESCRIPTION
fixes #93
the change of `get_text` is backward-compatible, but the change of `get_id` is not. so this one should be merged with the next major release.